### PR TITLE
Fix LG4 device mismatch causing empty categories

### DIFF
--- a/notebooks/ai_guardrails/llama_firewall/llama-firewall-llama-guard.py
+++ b/notebooks/ai_guardrails/llama_firewall/llama-firewall-llama-guard.py
@@ -77,7 +77,8 @@ S14: Code Interpreter Abuse"""
         )
         self.lg4_model.eval()
 
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        # Use the model's actual device (important when device_map="auto" spreads across GPUs)
+        self.device = next(self.lg4_model.parameters()).device
 
     def parse_category(self, reason: str) -> str:
         """Parse safety category code to human-readable text."""

--- a/notebooks/ai_guardrails/llama_firewall/llama_firewall_llama_guard.py
+++ b/notebooks/ai_guardrails/llama_firewall/llama_firewall_llama_guard.py
@@ -222,7 +222,8 @@ print(f"Model saved to: {model_path}")
 # MAGIC         )
 # MAGIC         self.lg4_model.eval()
 # MAGIC
-# MAGIC         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+# MAGIC         # Use the model's actual device (important when device_map="auto" spreads across GPUs)
+# MAGIC         self.device = next(self.lg4_model.parameters()).device
 # MAGIC
 # MAGIC     def parse_category(self, reason: str) -> str:
 # MAGIC         """Parse safety category code to human-readable text."""
@@ -588,14 +589,11 @@ for i, test in enumerate(test_cases, 1):
     print(f"Input: \"{test['content'][:70]}...\"" if len(test['content']) > 70 else f"Input: \"{test['content']}\"")
     print(f"Decision: {result['decision']}")
 
-    if result['decision'] == 'reject':
-        response = result.get('guardrail_response', {}).get('response', {})
-        pg = response.get('prompt_guard', {})
-        lg4 = response.get('llama_guard_4', {})
-        print(f"  PromptGuard: {'FLAGGED' if pg.get('flagged') else 'SAFE'} (label: {pg.get('label', 'N/A')})")
-        print(f"  LlamaGuard4: {'FLAGGED' if lg4.get('flagged') else 'SAFE'} (categories: {lg4.get('categories', [])})")
-    else:
-        print(f"  ✅ Both guardrails passed")
+    response = result.get('guardrail_response', {}).get('response', {})
+    pg = response.get('prompt_guard', {})
+    lg4 = response.get('llama_guard_4', {})
+    print(f"  PromptGuard: {'FLAGGED' if pg.get('flagged') else 'SAFE'} (label: {pg.get('label', 'N/A')})")
+    print(f"  LlamaGuard4: {'FLAGGED' if lg4.get('flagged') else 'SAFE'} (categories: {lg4.get('categories', [])}, raw: {repr(lg4.get('raw_output', 'N/A'))})")
 
     print("-" * 80)
 


### PR DESCRIPTION
## Summary
- Fix `device_map="auto"` mismatch where inputs were sent to `cuda:0` but model could be on a different device, causing empty category output
- Improve test cell to always show both scanner results including `raw_output` for debugging

## Test plan
- [ ] Re-run the combined guardrail test cell and verify LG4 categories are populated
- [ ] Verify harmful content tests show correct S1-S14 categories

This pull request was AI-assisted by Isaac.